### PR TITLE
Fix NullPointerExceptopn when getParent is null in applyToolTipPosition()

### DIFF
--- a/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
+++ b/lib/src/main/java/com/nhaarman/supertooltips/ToolTipView.java
@@ -102,7 +102,9 @@ public class ToolTipView extends LinearLayout implements ViewTreeObserver.OnPreD
         RelativeLayout.LayoutParams layoutParams = (RelativeLayout.LayoutParams) getLayoutParams();
         layoutParams.width = mWidth;
         setLayoutParams(layoutParams);
-
+        if (getParent() == null) {
+            return false;
+        }
         if (mToolTip != null) {
             applyToolTipPosition();
         }
@@ -152,7 +154,9 @@ public class ToolTipView extends LinearLayout implements ViewTreeObserver.OnPreD
         mView.getWindowVisibleDisplayFrame(viewDisplayFrame);
 
         final int[] parentViewScreenPosition = new int[2];
-        ((View) getParent()).getLocationOnScreen(parentViewScreenPosition);
+        if (getParent() != null) {
+            ((View) getParent()).getLocationOnScreen(parentViewScreenPosition);
+        }
 
         final int masterViewWidth = mView.getWidth();
         final int masterViewHeight = mView.getHeight();


### PR DESCRIPTION
Received several crashes in applyToolTipPosition(). Was using ToolTipView on a fragment inside ViewPager.

Stacktrace:

java.lang.NullPointerException
at com.haarman.supertooltips.ToolTipView.applyToolTipPosition(ToolTipView.java:138)
at com.haarman.supertooltips.ToolTipView.onPreDraw(ToolTipView.java:99)
at android.view.ViewTreeObserver.dispatchOnPreDraw(ViewTreeObserver.java:888)
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2173)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1246)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6567)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:803)
at android.view.Choreographer.doCallbacks(Choreographer.java:603)
at android.view.Choreographer.doFrame(Choreographer.java:573)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:789)
at android.os.Handler.handleCallback(Handler.java:733)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:136)
at android.app.ActivityThread.main(ActivityThread.java:5476)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1268)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1084)
at dalvik.system.NativeStart.main(Native Method)
